### PR TITLE
Ignore links to the repo for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,3 +146,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+        with:
+          ignore_links: https://github.com/TileDB-Inc/jupyter-iframe-commands/.*


### PR DESCRIPTION
The `check_links` check seems to be failing on CI, probably because the repo is private.

We can ignore the links to the repo for now, and re-add them later when the repo is public, so we have a CI fully passing.