### PR TITLE
Minimal demo for ghpages using jupyter lite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,71 +15,71 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Base Setup
-      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-    - name: Install dependencies
-      run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+      - name: Install dependencies
+        run: python -m pip install -U "jupyterlab>=4.0.0,<5"
 
-    - name: Lint the extension
-      run: |
-        set -eux
-        jlpm
-        jlpm run lint:check
+      - name: Lint the extension
+        run: |
+          set -eux
+          jlpm
+          jlpm run lint:check
 
-    - name: Build the extension
-      run: |
-        set -eux
-        python -m pip install .[test]
+      - name: Build the extension
+        run: |
+          set -eux
+          python -m pip install .[test]
 
-        jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "jupyter-iframe-commands.*OK"
-        python -m jupyterlab.browser_check
+          jupyter labextension list
+          jupyter labextension list 2>&1 | grep -ie "jupyter-iframe-commands.*OK"
+          python -m jupyterlab.browser_check
 
-    - name: Package the extension
-      run: |
-        set -eux
+      - name: Package the extension
+        run: |
+          set -eux
 
-        pip install build
-        python -m build
-        pip uninstall -y "jupyter_iframe_commands" jupyterlab
+          pip install build
+          python -m build
+          pip uninstall -y "jupyter_iframe_commands" jupyterlab
 
-    - name: Upload extension packages
-      uses: actions/upload-artifact@v4
-      with:
-        name: extension-artifacts
-        path: dist/jupyter_iframe_commands*
-        if-no-files-found: error
+      - name: Upload extension packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-artifacts
+          path: dist/jupyter_iframe_commands*
+          if-no-files-found: error
 
   test_isolated:
     needs: build
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.9'
-        architecture: 'x64'
-    - uses: actions/download-artifact@v4
-      with:
-        name: extension-artifacts
-    - name: Install and Test
-      run: |
-        set -eux
-        # Remove NodeJS, twice to take care of system and locally installed node versions.
-        sudo rm -rf $(which node)
-        sudo rm -rf $(which node)
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+      - uses: actions/download-artifact@v4
+        with:
+          name: extension-artifacts
+      - name: Install and Test
+        run: |
+          set -eux
+          # Remove NodeJS, twice to take care of system and locally installed node versions.
+          sudo rm -rf $(which node)
+          sudo rm -rf $(which node)
 
-        pip install "jupyterlab>=4.0.0,<5" jupyter_iframe_commands*.whl
+          pip install "jupyterlab>=4.0.0,<5" jupyter_iframe_commands*.whl
 
 
-        jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "jupyter-iframe-commands.*OK"
-        python -m jupyterlab.browser_check --no-browser-test
+          jupyter labextension list
+          jupyter labextension list 2>&1 | grep -ie "jupyter-iframe-commands.*OK"
+          python -m jupyterlab.browser_check --no-browser-test
 
   integration-tests:
     name: Integration tests
@@ -90,53 +90,53 @@ jobs:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Base Setup
-      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-    - name: Download extension package
-      uses: actions/download-artifact@v4
-      with:
-        name: extension-artifacts
+      - name: Download extension package
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-artifacts
 
-    - name: Install the extension
-      run: |
-        set -eux
-        python -m pip install "jupyterlab>=4.0.0,<5" jupyter_iframe_commands*.whl
+      - name: Install the extension
+        run: |
+          set -eux
+          python -m pip install "jupyterlab>=4.0.0,<5" jupyter_iframe_commands*.whl
 
-    - name: Install dependencies
-      working-directory: ui-tests
-      env:
-        YARN_ENABLE_IMMUTABLE_INSTALLS: 0
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      run: jlpm install
+      - name: Install dependencies
+        working-directory: ui-tests
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: 0
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+        run: jlpm install
 
-    - name: Set up browser cache
-      uses: actions/cache@v4
-      with:
-        path: |
-          ${{ github.workspace }}/pw-browsers
-        key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
+      - name: Set up browser cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/pw-browsers
+          key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
 
-    - name: Install browser
-      run: jlpm playwright install chromium
-      working-directory: ui-tests
+      - name: Install browser
+        run: jlpm playwright install chromium
+        working-directory: ui-tests
 
-    - name: Execute integration tests
-      working-directory: ui-tests
-      run: |
-        jlpm playwright test
+      - name: Execute integration tests
+        working-directory: ui-tests
+        run: |
+          jlpm playwright test
 
-    - name: Upload Playwright Test report
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: jupyter_iframe_commands-playwright-tests
-        path: |
-          ui-tests/test-results
-          ui-tests/playwright-report
+      - name: Upload Playwright Test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jupyter_iframe_commands-playwright-tests
+          path: |
+            ui-tests/test-results
+            ui-tests/playwright-report
 
   check_links:
     name: Check Links
@@ -148,3 +148,43 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_links: https://github.com/TileDB-Inc/jupyter-iframe-commands/.*
+
+  build-lite:
+    name: Build JupyterLite
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install the dependencies
+        run: |
+          python -m pip install -r requirements.txt
+      - name: Build the JupyterLite site
+        run: |
+          jupyter lite build --contents README.md --output-dir demo/lite
+      - name: Upload artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./demo
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ dmypy.json
 
 # Yarn cache
 .yarn/
+
+# lite build for demo
+demo/lite

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Parent</title>
+    <title>Demo</title>
     <script type="module">
       import * as Comlink from 'https://unpkg.com/comlink/dist/esm/comlink.mjs';
 
@@ -27,12 +27,31 @@
     </script>
   </head>
   <body>
-    <h1>Parent Page</h1>
+    <div
+      style="display: flex; align-items: center; justify-content: space-around"
+    >
+      <h1>Demo</h1>
+      <div>
+        <form id="commands">
+          <input type="text" name="command" placeholder="Enter a command" />
+          <button type="submit">Submit</button>
+        </form>
+      </div>
+    </div>
+
     <iframe
       id="jupyterlab"
       src="./lite/index.html"
       sandbox="allow-scripts allow-same-origin"
       style="width: 100%; height: 100vh"
     ></iframe>
+
+    <script>
+      document.getElementById('commands').addEventListener('submit', e => {
+        e.preventDefault();
+        const command = document.querySelector('input[name="command"]').value;
+        commandBridge.execute(command);
+      });
+    </script>
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,7 @@
     <h1>Parent Page</h1>
     <iframe
       id="jupyterlab"
-      src="http://localhost:8888"
+      src="./lite/index.html"
       sandbox="allow-scripts allow-same-origin"
       style="width: 100%; height: 100vh"
     ></iframe>

--- a/demo/index.html
+++ b/demo/index.html
@@ -34,6 +34,7 @@
       <div>
         <form id="commands">
           <input type="text" name="command" placeholder="Enter a command" />
+          <input type="text" name="args" placeholder="Enter args (optional)" />
           <button type="submit">Submit</button>
         </form>
       </div>
@@ -50,7 +51,12 @@
       document.getElementById('commands').addEventListener('submit', e => {
         e.preventDefault();
         const command = document.querySelector('input[name="command"]').value;
-        commandBridge.execute(command);
+
+        // Single quotes cause an error
+        const args = document
+          .querySelector('input[name="args"]')
+          .value.replace(/'/g, '"');
+        commandBridge.execute(command, args ? JSON.parse(args) : null);
       });
     </script>
   </body>

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -3,7 +3,8 @@
   "jupyter-config-data": {
     "disabledExtensions": [
       "@jupyterlab/mainmenu-extension",
-      "@jupyterlite/application-extension:logo"
+      "@jupyterlite/application-extension:logo",
+      "@jupyterlab/help-extension:resources"
     ]
   }
 }

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -1,6 +1,11 @@
 {
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
-    "disabledExtensions": ["jupyterlab-kernel-spy", "jupyterlab-tour"]
+    "disabledExtensions": [
+      "jupyterlab-kernel-spy",
+      "jupyterlab-tour",
+      "@jupyterlab/mainmenu-extension",
+      "@jupyterlite/application-extension:logo"
+    ]
   }
 }

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -2,8 +2,6 @@
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
     "disabledExtensions": [
-      "jupyterlab-kernel-spy",
-      "jupyterlab-tour",
       "@jupyterlab/mainmenu-extension",
       "@jupyterlite/application-extension:logo"
     ]

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -1,0 +1,6 @@
+{
+  "jupyter-lite-schema-version": 0,
+  "jupyter-config-data": {
+    "disabledExtensions": ["jupyterlab-kernel-spy", "jupyterlab-tour"]
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# Core modules (mandatory)
+jupyterlite-core==0.4.4
+jupyterlab~=4.2.5
+notebook~=7.2.2
+
+# JupyterLab: dark theme
+jupyterlab-night
+# JupyterLab: Miami nights theme (optional)
+jupyterlab_miami_nights

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ jupyterlite-core==0.4.4
 jupyterlite-pyodide-kernel==0.4.4
 jupyterlab~=4.2.5
 notebook~=7.2.2
+.
 
 # JupyterLab: dark theme
 jupyterlab-night

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core modules (mandatory)
 jupyterlite-core==0.4.4
+jupyterlite-pyodide-kernel==0.4.4
 jupyterlab~=4.2.5
 notebook~=7.2.2
 


### PR DESCRIPTION
Addresses #2. Provides a minimal demo with Jupyter Lite with an input field that allows sending arbitrary commands from the host page. Includes a `jupyter-lite.json` to showcase disabling extensions to remove UI elements from the base UI. 
