### PR TITLE
Split local lab and lite demos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,12 +165,12 @@ jobs:
           python -m pip install -r requirements.txt
       - name: Build the JupyterLite site
         run: |
-          jupyter lite build --contents README.md --output-dir demo/lite
+          jupyter lite build --contents README.md --output-dir ghpages/lite
       - name: Upload artifact
         id: deployment
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./demo
+          path: ./ghpages
 
   deploy:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -125,4 +125,5 @@ dmypy.json
 .yarn/
 
 # lite build for demo
-demo/lite
+ghpages/lite
+.jupyterlite.doit.db

--- a/demo/jupyter_server_config.py
+++ b/demo/jupyter_server_config.py
@@ -2,12 +2,12 @@
 c.ServerApp.open_browser = False
 
 # disable the token for easier testing in an IFrame
-c.ServerApp.token = ''
+c.ServerApp.token = ""
 
 # Allow embedding JupyterLab in an IFrame from a specific host
 c.ServerApp.tornado_settings = {
-    'headers': {
-        'Content-Security-Policy': "frame-ancestors 'self' http://localhost:8080"
+    "headers": {
+        "Content-Security-Policy": "frame-ancestors 'self' http://localhost:8080 http://127.0.0.1:8080"
     }
 }
-c.ServerApp.allow_origin = 'http://localhost:8080'
+c.ServerApp.allow_origin = "http://localhost:8080"

--- a/ghpages/index.html
+++ b/ghpages/index.html
@@ -30,7 +30,7 @@
     <div
       style="display: flex; align-items: center; justify-content: space-around"
     >
-      <h1>Local Demo</h1>
+      <h1>Demo</h1>
       <div>
         <form id="commands">
           <input type="text" name="command" placeholder="Enter a command" />
@@ -42,7 +42,7 @@
 
     <iframe
       id="jupyterlab"
-      src="http://localhost:8888"
+      src="./lite/index.html"
       sandbox="allow-scripts allow-same-origin"
       style="width: 100%; height: 100vh"
     ></iframe>


### PR DESCRIPTION
As suggested in #14, this creates two versions of the demo, one using JupyterLite for the demo on GitHub Pages, and the second using JupyterLab locally which can be started using the current instructions in the README