### PR TITLE
Fix check-release workflow

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -19,14 +19,6 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-      - name: Install the dependencies
-        run: |
-          set -eux
-          python -m pip install -r requirements.txt
-          jlpm
-          jlpm build
-          python -m pip install .
-
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:


### PR DESCRIPTION
Looking into preparing this repo for use with the Jupyter Releaser, so we have automated releases in place and 

- [x] Remove the explicit build from `check-release` workflow since the real release workflows would not perform that step 
- [x] Make sure both the companion and the extension packages are built on CI