### PR TITLE
Add script to build npm tarballs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,12 @@ jobs:
 
           jupyter labextension list 2>&1 | grep -ie "jupyter-iframe-commands.*OK"
 
+      - name: Build the npm packages
+        run: |
+          set -eux
+
+          jlpm build:npm:dist
+
       - name: Package the extension
         run: |
           set -eux
@@ -47,12 +53,6 @@ jobs:
           pip install build
           python -m build
           pip uninstall -y "jupyter_iframe_commands" jupyterlab
-
-      - name: Build the npm packages
-        run: |
-          set -eux
-
-          jlpm build:npm:dist
 
       - name: Upload extension packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,12 @@ jobs:
           python -m build
           pip uninstall -y "jupyter_iframe_commands" jupyterlab
 
+      - name: Build the npm packages
+        run: |
+          set -eux
+
+          jlpm build:npm:dist
+
       - name: Upload extension packages
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: extension-artifacts
-          path: dist/jupyter_iframe_commands*
+          path: dist/*
           if-no-files-found: error
 
   test_isolated:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "build": "lerna run build",
     "build:prod": "lerna run build:prod",
+    "build:dist": "yarn build:prod && mkdir -p dist && lerna exec --no-private -- npm pack --pack-destination ../../dist",
     "clean": "lerna run clean",
     "clean:all": "lerna run clean:all",
     "eslint": "jlpm eslint:check --fix",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "lerna run build",
     "build:prod": "lerna run build:prod",
-    "build:npm:dist": "yarn build:prod && mkdir -p dist && lerna exec --no-private -- npm pack --pack-destination ../../dist",
+    "build:npm:dist": "jlpm build:prod && mkdir -p dist && lerna exec --no-private -- npm pack --pack-destination ../../dist",
     "clean": "lerna run clean",
     "clean:all": "lerna run clean:all",
     "eslint": "jlpm eslint:check --fix",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "lerna run build",
     "build:prod": "lerna run build:prod",
-    "build:dist": "yarn build:prod && mkdir -p dist && lerna exec --no-private -- npm pack --pack-destination ../../dist",
+    "build:npm:dist": "yarn build:prod && mkdir -p dist && lerna exec --no-private -- npm pack --pack-destination ../../dist",
     "clean": "lerna run clean",
     "clean:all": "lerna run clean:all",
     "eslint": "jlpm eslint:check --fix",


### PR DESCRIPTION
Until we have #27 

So both the Python and npm packages are built on CI and put in the `extension-artifacts` uploaded by GitHub Actions.