### PR TITLE
Expose `createProxy`

### DIFF
--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) TileDB, Inc.
 // Distributed under the terms of the Modified BSD License.
-import { windowEndpoint, wrap } from 'comlink';
+import { windowEndpoint, wrap, proxy, ProxyOrClone } from 'comlink';
+
 import { ICommandBridgeRemote } from 'jupyter-iframe-commands';
 /**
  * A bridge to expose actions on JupyterLab commands.
@@ -21,4 +22,14 @@ export function createBridge({ iframeId }: { iframeId: string }) {
   }
 
   return wrap<ICommandBridgeRemote>(windowEndpoint(iframe.contentWindow));
+}
+
+/**
+ * Creates a proxy for the given object.
+ *
+ * @param args - The object to create a proxy for.
+ * @returns A proxy for the given object.
+ */
+export function createProxy(args: any): ProxyOrClone<any> {
+  return proxy(args);
 }

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -4,5 +4,10 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../extension"
+    }
+  ]
 }


### PR DESCRIPTION
Alternative to https://github.com/TileDB-Inc/jupyter-iframe-commands/pull/42.

Provide a `createProxy` to more conveniently register callbacks that can be invoked from an extension in the IFrame.

Based on `Comlink.proxy` used for callbacks: https://github.com/GoogleChromeLabs/comlink?tab=readme-ov-file#callbacks

## Changes

- [x] Expose `createProxy` from `jupyter-iframe-commands-host`
- [ ] Document usage 

## Example

### Host

```js
import { createBridge, createProxy } from 'jupyter-iframe-commands-host';

const commandBridge = createBridge({ iframeId: 'jupyterlab' });

const kernelStatus = async ({ displayName, isBusy }) => {
  console.log('Received kernel status update from the iframe');
  console.log('Display Name:', displayName);
  console.log('Is Busy:', isBusy);
};

await commandBridge.execute('kernel-status', createProxy({ kernelStatus }));
```

### Custom extension

```ts
const demoPlugin: JupyterFrontEndPlugin<void> = {
  id: 'jupyter-iframe-commands:demo-callback',
  autoStart: true,
  description: 'A demo plugin to show how to use the jupyter-iframe-commands.',
  requires: [ILabStatus, INotebookTracker],
  activate: async (
    app: JupyterFrontEnd,
    labStatus: ILabStatus,
    tracker: INotebookTracker
  ) => {
    const { commands } = app;

    commands.addCommand('kernel-status', {
      label: 'Kernel Status',
      execute: args => {
        console.log('Kernel status command executed with args:', args);

        const kernelStatus = args['kernelStatus'] as unknown as (
          args?: any
        ) => void;

        labStatus.busySignal.connect(async () => {
          const kernelSpec =
            await tracker.currentWidget?.sessionContext?.session?.kernel?.spec;
          const displayName = kernelSpec
            ? kernelSpec.display_name
            : 'Loading...';
          kernelStatus({ displayName, isBusy: labStatus.isBusy });
        });
      }
    });
  }
};
```

When testing the above snippets with the demo:

https://github.com/user-attachments/assets/043a196b-4baf-4974-a678-87e815933ed2


