### PR TITLE
Rename message to report when the extension is ready

### DIFF
--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -66,7 +66,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     app.started.then(() => {
       const endpoint = windowEndpoint(self.parent);
       expose(api, endpoint);
-      window.parent?.postMessage('extension-loaded', '*');
+      window.parent?.postMessage('_JUPYTER_IFRAME_COMMANDS_LOADED', '*');
     });
   }
 };

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -36,7 +36,7 @@ export function createBridge({
     const signal = controller.signal;
 
     const messageHandler = (event: MessageEvent) => {
-      if (event.data === 'extension-loaded') {
+      if (event.data === '_JUPYTER_IFRAME_COMMANDS_LOADED') {
         controller.abort();
         resolve();
       }


### PR DESCRIPTION
Quick follow-up to https://github.com/TileDB-Inc/jupyter-iframe-commands/pull/46

Using an all caps with a leading underscore to indicate this is meant for internal communication between the extension and the host package.